### PR TITLE
Fix installation of packages + use of become

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ atom_ver : '1.2.3'
 atom_mirror : 'https://github.com/atom/atom/releases/download'
 atom_deb_platform : 'amd64'
 atom_rpm_platform : 'x86_64'
-atom_packages_packages: [ ]
+atom_packages: [ ]
 ````
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,6 @@ atom_ver : '1.2.3'
 atom_mirror : 'https://github.com/atom/atom/releases/download'
 atom_deb_platform : 'amd64'
 atom_rpm_platform : 'x86_64'
-atom_packages_packages: [ ]
+atom_packages: [ ]
 atom_user: 'root'
 atom_desktop_icon: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,10 +15,10 @@
   shell: cp /usr/share/applications/{{ item }} /home/{{ atom_user }}/Desktop; chmod +x /home/{{ atom_user }}/Desktop/{{ item }};
   with_items:
     - atom.desktop
-  become: "{{ atom_user }}"
+  become_user: "{{ atom_user }}"
   when: "{{ atom_desktop_icon }}"
 
 - name: Installing Atom packages
   shell: "apm install {{ item }} --production --silent"
   with_items: "{{ atom_packages }}"
-  become: "{{ atom_user }}"
+  become_user: "{{ atom_user }}"


### PR DESCRIPTION
- Fixed installation of packages: the variable actually used in the role is atom_packages
- to become another user, use become_user
